### PR TITLE
Change ClientHandler to handle SSLException

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ClientHandler.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/nhttp/ClientHandler.java
@@ -417,6 +417,9 @@ public class ClientHandler implements NHttpClientEventHandler {
      * @param ex the exception encountered
      */
     public void exception(final NHttpClientConnection conn, final Exception ex) {
+        HttpContext context = conn.getContext();
+        Axis2HttpRequest axis2Req = (Axis2HttpRequest) context.getAttribute(ATTACHMENT_KEY);
+        context.setAttribute(AXIS2_HTTP_REQUEST, axis2Req);
 
         if (ex instanceof HttpException) {
             String message = getErrorMessage("HTTP protocol violation : " + ex.getMessage(), conn);


### PR DESCRIPTION
Hi,

Currently at a situation where there's no certificate or certificate expiration, ESB shows SSLException but error messages are not handled by fault-sequence. This happens in nhttp-transport. With this fix, those messages are send to fault-sequence.

Thank You!