### PR TITLE
Enabling json expressions as values

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
@@ -83,7 +83,12 @@ public class SynapsePathSerializer {
 		if (path != null && expression != null) {
 
             if(path.getPathType() == SynapsePath.JSON_PATH) {
-			    elem.setText("json-eval(" + expression + ")");
+                if (expression.contains("json-eval(")) {
+                    // JSON evaluation expression as a value. eg: {json-eval($.)}
+                    elem.setText(expression);
+                } else {
+                    elem.setText("json-eval(" + expression + ")");
+                }
             } else if(path.getPathType() == SynapsePath.X_PATH) {
                 elem.setText(expression);
             }

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/SynapsePathSerializer.java
@@ -61,8 +61,13 @@ public class SynapsePathSerializer {
         if (path != null && expression != null) {
 
             if(path.getPathType() == SynapsePath.JSON_PATH) {
-                elem.addAttribute(elem.getOMFactory().createOMAttribute(
-                        attribName, nullNS, "json-eval(" + expression + ")"));
+                if (expression.contains("json-eval(")) {
+                    elem.addAttribute(elem.getOMFactory().createOMAttribute(
+                            attribName, nullNS, expression));
+                } else {
+                    elem.addAttribute(elem.getOMFactory().createOMAttribute(
+                            attribName, nullNS, "json-eval(" + expression + ")"));
+                }
             } else if(path.getPathType() == SynapsePath.X_PATH) {
                 elem.addAttribute(elem.getOMFactory().createOMAttribute(
                         attribName, nullNS, expression));

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/ValueSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/ValueSerializer.java
@@ -53,7 +53,7 @@ public class ValueSerializer {
                     endChar = endChar + "}";
                 }
                 //dynamic key
-                SynapseXPathSerializer.serializeXPath(key.getExpression(), startChar +
+                SynapsePathSerializer.serializePath(key.getExpression(), startChar +
                         key.getExpression().toString() + endChar, elem, name);
             }
         }
@@ -81,7 +81,7 @@ public class ValueSerializer {
 					endChar = endChar + "}";
 				}
 				// dynamic key
-				SynapseXPathSerializer.serializeTextXPath(key.getExpression(), startChar
+				SynapsePathSerializer.serializeTextPath(key.getExpression(), startChar
 						+ key.getExpression().toString() + endChar, elem, name);
 			}
 		}

--- a/modules/core/src/main/java/org/apache/synapse/mediators/Value.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/Value.java
@@ -24,6 +24,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.xml.SynapsePath;
+import org.apache.synapse.util.xpath.SynapseJsonPath;
 import org.apache.synapse.util.xpath.SynapseXPath;
 import org.jaxen.JaxenException;
 
@@ -52,7 +54,7 @@ public class Value {
     /**
      * the dynamic key
      */
-    private SynapseXPath expression = null;
+    private SynapsePath expression = null;
 
     private List<OMNamespace> namespaceList = new ArrayList<OMNamespace>();
     /**
@@ -65,11 +67,11 @@ public class Value {
     }
 
     /**
-     * Create a key instance using a dynamic key (Xpath Expression)
+     * Create a key instance using a dynamic key (Xpath or JsonPath Expression)
      *
-     * @param expression SynapseXpath for dynamic key
+     * @param expression SynapsePath for dynamic key
      */
-    public Value(SynapseXPath expression) {
+    public Value(SynapsePath expression) {
         this.expression = expression;
     }
 
@@ -85,15 +87,16 @@ public class Value {
     /**
      * Retrieving dynamic key
      *
-     * @return SynapseXpath
+     * @return SynapsePath
      */
-    public SynapseXPath getExpression() {
+    public SynapsePath getExpression() {
         if(expression == null && keyValue != null && hasExprTypeKey()){
             try {
-                expression = new SynapseXPath (keyValue.substring(1, keyValue.length()-1));
+                SynapseXPath expressionTypeKey = new SynapseXPath(keyValue.substring(1, keyValue.length() - 1));
                 for (OMNamespace aNamespaceList : namespaceList) {
-                    expression.addNamespace(aNamespaceList);
+                    expressionTypeKey.addNamespace(aNamespaceList);
                 }
+                expression = expressionTypeKey;
             } catch (JaxenException e) {
                 expression = null;
                 handleException("Can not evaluate escaped expression..");

--- a/modules/core/src/main/java/org/apache/synapse/mediators/bean/Target.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/bean/Target.java
@@ -57,9 +57,9 @@ public class Target {
      */
     public void insert(MessageContext synCtx, Object object) {
 
-        if (value.getExpression() != null) {
+        if (value.getExpression() != null && value.getExpression() instanceof SynapseXPath) {
 
-            SynapseXPath expression = value.getExpression();
+            SynapseXPath expression = (SynapseXPath)value.getExpression();
             Object targetObj = null;
 
             try {


### PR DESCRIPTION
We have came across a requirement of using json-eval expressions as values.

So that configuration can have ```<message>{json-eval($.text)}</message>```, which will give the same output as ```expression="json-eval($.text)"```.

Also, This will reduce the overhead of converting messages into XML in such cases.